### PR TITLE
prefilter in pandas, use one sqlalchemy session, and use futures to c…

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -180,6 +180,6 @@ engine = create_engine(Config.connection_string)
 # So just don't do it. To upgrade the database run alembic upgrade head
 # Base.metadata.create_all(engine)
 
-session_factory = sessionmaker(bind=engine)
+session_factory = sessionmaker(bind=engine, autoflush=False)
 Session = scoped_session(session_factory)
 SqlLock = Lock()

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -1,10 +1,12 @@
 import os
 import time
-import traceback as tb
 from abc import ABC, abstractmethod
 from collections import namedtuple
+from datetime import datetime as dt
 from threading import Thread, Lock
 
+import pandas as pd
+import pytz
 import requests as rq
 import validators
 from bs4 import BeautifulSoup as Soup, Tag, NavigableString  # noqa not declared in __all__
@@ -50,6 +52,7 @@ class Scraper(ABC, Thread):
 
     def __init__(self):
         super().__init__()
+        self.success = False
         self.rq = rq.Session()
         self.articles = 0
         self.headlines = 0
@@ -61,8 +64,8 @@ class Scraper(ABC, Thread):
             raise ValueError("URL must be set")
         if self.bias is None or self.credibility is None:
             raise ValueError("Bias and credibility must be set")
-        self.times = []
         self.downstream: list[tuple[str, Tag]] = []
+        self.prefiltered = []
         self.done: bool = False
         self.results: list[dict[str, str]] = []
         with Session() as session, self.sql_lock:
@@ -83,38 +86,6 @@ class Scraper(ABC, Thread):
     def setup(self, soup: Soup):
         pass
 
-    def process(self, art: ArticleTuple):
-        with Session() as s:
-            if (headline := s.query(Headline).filter(Headline.processed == art.processed).first()) is not None:
-                # we're going to double-check this headline hasn't been seen before
-                headline.update_last_accessed()
-                headline.article.update_last_accessed()
-                self.updated += 1
-                s.commit()
-                return
-
-            if (article := s.query(Article).filter_by(url=art.href).first()) is None:
-                article = Article(url=art.href, agency_id=self.agency_id)
-                s.add(article)
-                s.commit()
-                logger.debug(f"Added to database: %r", article)
-                self.articles += 1
-
-            article.update_last_accessed()  # if its new this does nothing, if it's not we need to do it!
-            headline = Headline(
-                title=art.title,
-                raw=art.raw,
-                processed=art.processed,
-                position=art.pos,
-                article_id=article.id
-            )
-            s.add(headline)
-            s.commit()
-            logger.debug(f"Added to database: %r", headline)
-            s.expunge(headline)
-        metrics.apply(headline)
-        self.headlines += 1
-
     def get_page(self, url: str):
         if not self.headers:
             self.headers = {'User-Agent': Constants.Headers.UserAgents.maudlin}
@@ -122,60 +93,116 @@ class Scraper(ABC, Thread):
         try:
             response: rq.Response = self.rq.get(url, headers=self.headers, timeout=Config.timeout)
         except Exception as e:  # noqa
-            raise ValueError(f"Failed to get page: {url} {e}")
+            logger.error("Failed to get page: %s %s", url, e)
+            return
         if not response.ok:
-            raise ValueError("Bad response for %s: %s" % (url, response.status_code))
+            logger.error("Bad response for %s: %s", url, response.status_code)
+            return
         else:
             logger.info(f"Downloaded {url}")
-        return Soup(response.content, self.parser)
+        soup = Soup(response.content, self.parser)
+        self.success = True
+        return soup
 
     def run(self):
         self.run_setup()
         self.done = True
 
     def post_run(self):
+        t = time.time()
         self.run_processing()
+        runtime = time.time() - t
         self.dayreport.headlines(self.headlines)
         self.dayreport.articles(self.articles)
         self.dayreport.updated(self.updated)
-        # If we didn't get anything we want to warn!
-        bugle = logger.info if self.articles + self.headlines + self.updated else logger.warning
-        total_time = sum(self.times)
-        mean_time = total_time / len(self.times) if self.times else 0
-        bugle("%s: %d found, %d articles, %d headlines, %d updated in %f seconds with a mean time of %f",
-              self.agency, self.found, self.articles, self.headlines, self.updated, total_time, mean_time)
+        meantime = 0
+        if self.found:
+            meantime = runtime / self.found
+        # If we didn't got headlines but nothing processed we want to warn
+        bugle = logger.info if not self.found or self.articles + self.headlines + self.updated else logger.warning
+        bugle("%s: %d found, added %d articles, %d headlines, updated %d in %f seconds with a mean time of %f",
+              self.agency, self.found, self.articles, self.headlines, self.updated, runtime, meantime)
+
+    def prefilter(self, downstream):
+        df = pd.DataFrame(downstream, columns=['href', 'raw'])
+        df['raw'] = df['raw'].apply(str)
+
+        df['row'] = df.index
+        df['row'] = df['row'].astype(int)
+
+        t = time.time()
+        df['href'] = df['href'].apply(self.clean_href)
+        df['validate'] = df['href'].apply(lambda x: bool(validators.url(x)))
+        # Headlines with invalid urls are not headlines
+        df.drop(df[df['validate'] == False].index, inplace=True)  # noqa
+        logger.debug("Dropping headlines with invalid urls in %f seconds", time.time() - t)
+
+        t = time.time()
+        df['title'] = df['raw'].apply(lambda x: ' '.join(extract_text(str(x))))
+        logger.debug("Extracted text in %f seconds", time.time() - t)
+
+        t = time.time()
+        df['word_count'] = df['title'].apply(lambda x: x.count(' '))
+        # Headlines without spaces are not headlines
+        df.drop(df[df['word_count'] == 0].index, inplace=True)
+        logger.debug("Dropping headlines without spaces in %f seconds", time.time() - t)
+
+        t = time.time()
+        df['processed'] = df['title'].apply(preprocess)
+        # Headlines without processed text are not headlines
+        df.drop(df[df['processed'].isnull()].index, inplace=True)
+        logger.debug("Dropping headlines without processed text in %f seconds", time.time() - t)
+
+        with Session() as s:
+            seen = s.query(Headline.processed, Headline.id, Article.id).join(Headline.article).filter(
+                Headline.processed.in_(df['processed'].tolist())
+            ).all()
+            df['seen'] = df['processed'].isin([x[0] for x in seen])
+            df.drop(df[df['seen'] == True].index, inplace=True)  # noqa
+            dropped = len(seen)
+            self.updated += dropped
+            s.query(Headline).filter(Headline.id.in_([x[1] for x in seen])).update({'last_accessed': dt.now(pytz.UTC)})
+            s.query(Article).filter(Article.id.in_([x[2] for x in seen])).update({'last_accessed': dt.now(pytz.UTC)})
+            s.commit()
+
+        df['artpair'] = df.apply(lambda x: ArticleTuple(x['href'], x['raw'], x['title'], x['processed'], x['row']),
+                                 axis=1)
+        return dropped, df['artpair'].tolist()
 
     def run_processing(self):
         self.found = len(self.downstream)
         logger.info("Processing %s, %i upstream headlines", self.agency, self.found)
-        self.times = list(
-            filter(
-                None,
-                [self.process_item(pos, href, raw) for pos, (href, raw) in enumerate(self.downstream)]
-            )
-        )
-
-    def process_item(self, pos, href, raw):
         t = time.time()
-        raw = str(raw)
-        title = ' '.join(filter(None, extract_text(raw)))
-        if title.strip().count(' ') == 0:
-            return time.time() - t  # obviously a headline without spaces isn't a headline
-        processed = preprocess(title)
-        if not processed:
-            return time.time() - t
-        art = ArticleTuple(self.clean_href(href).strip(), str(raw), title, processed, pos)
-        pos += 1
-        try:
-            if not (err := validators.url(art.href)):
-                raise err
-            self.process(art)
-        except Exception as e:  # noqa
-            Session.rollback()
-            msg = f"Failed to process link: {self.agency}: {art} {e}"
-            self.dayreport.add_exception(msg, tb.format_exc())
-            logger.exception(msg)
-        return time.time() - t
+        dropped, prefiltered = self.prefilter(self.downstream)
+        logger.info("Prefiltered %i headlines in %f seconds", dropped, time.time() - t)
+        with Session() as s:
+            [self.process(s, art_pair) for art_pair in prefiltered]
+            s.commit()
+
+    def process(self, s, art: ArticleTuple):
+        if (headline := s.query(Headline).filter(Headline.processed == art.processed).first()) is not None:
+            # we're going to double-check this headline hasn't been seen before
+            headline.update_last_accessed()
+            headline.article.update_last_accessed()
+            self.updated += 1
+            return
+
+        if (article := s.query(Article).filter_by(url=art.href).first()) is None:
+            article = Article(url=art.href, agency_id=self.agency_id)
+            s.add(article)
+            self.articles += 1
+
+        article.update_last_accessed()  # if its new this does nothing, if it's not we need to do it!
+        headline = Headline(
+            title=art.title,
+            raw=art.raw,
+            processed=art.processed,
+            position=art.pos,
+            article=article
+        )
+        s.add(headline)
+        metrics.apply(headline, s)
+        self.headlines += 1
 
     def clean_href(self, href):
         if href.startswith('//'):
@@ -184,18 +211,13 @@ class Scraper(ABC, Thread):
             href = self.url.strip('/') + href
         elif not href.startswith('http'):
             href = self.url.strip('/') + '/' + href
-        return href
+        return href.strip()
 
     def run_setup(self):
-        try:
-            self.setup(self.get_page(self.url))
-            # self.filter_seen()
-        except Exception as e:  # noqa
-            Session.rollback()
-            msg = f"Failed to setup: {e} for {self.url}"
-            logger.exception(msg)
-            self.dayreport.add_exception(msg, tb.format_exc())
-            raise
+        page = self.get_page(self.url)
+        if not page:
+            return
+        self.setup(page)
 
 
 class SeleniumResourceManager:
@@ -229,14 +251,17 @@ class SeleniumScraper(Scraper):
     def __init__(self):
         super().__init__()
         self.srs = SeleniumResourceManager()
+        self.success = False
 
     def get_page(self, url: str):
         try:
-            logger.info("Downloading %s...", url)
+            t = time.time()
             soup = Soup(self.srs.get_html(url), self.parser)
-            logger.info("Downloaded %s", url)
+            logger.info("Downloaded %s in %i seconds", url, time.time() - t)
+            self.success = True
         except Exception as e:  # noqa
-            raise ValueError(f"Failed to get page: {e}")
+            logger.error("Failed to get page: %s %s", url, e)
+            return
         return soup
 
     @abstractmethod

--- a/app/site/page_headlines.py
+++ b/app/site/page_headlines.py
@@ -90,8 +90,9 @@ class HeadlinesPage:
                     last_bias = a['bias']
                 mean_sentiment = (a['afinn'] + a['vader_compound']) / 2
                 smiley = '😐' if mean_sentiment == 0 else '😊' if mean_sentiment > 0 else '😠'
+                bias = a['bias'] + 3
                 hrefs.append(
-                    f'<a class="storylink" style="background-color: {bias_colors[a['bias'] + 3]}"'
+                    f'<a class="storylink" style="background-color: {bias_colors[bias]}"'
                     f' href="{a["url"]}">{a["agency"]} {smiley}</a>'
                 )
             agency_lists[cluster['cluster']] = ' '.join(hrefs)

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -24,8 +24,9 @@ class SpecialDate:
 
 
 class Config:
+    max_threads = 100
     use_color = True
-    logging_level = logging.INFO
+    logging_level = logging.DEBUG
     debug: bool = False
     site_name = 'Maudlin'
     strf = '%Y-%m-%d %H:%M:%S'


### PR DESCRIPTION
1. Prefilter headlines in pandas for updates
2. Use futures for thread management on scrapers so that we don't get stuck in a queue waiting for one thread to finish
3. Use a single sqlalchemy session instead of committing for every change

Previous commits took me from 30 minutes to 15. This one takes me from 15 to 3